### PR TITLE
Allows checkbox item to be disabled.

### DIFF
--- a/src/components/inputs/partials/CheckboxPartial.vue
+++ b/src/components/inputs/partials/CheckboxPartial.vue
@@ -5,6 +5,7 @@
     :name="filter.key + option.key"
     :id="filter.key + option.key"
     :value="option.key"
+    :disabled="option.disabled"
     v-model="boundValue"
     :aria-labelledby="filter.key + option.key + '-label'"
   />


### PR DESCRIPTION
# Description
Allows checkbox items to be disabled/enabled.

# Changes
Added `:disabled="option.disabled"` to the checkbox component.

# How to test

using this branch within the ui template package development branch:
- add a checkbox filter
- add an `afterSet` method to the filter
- call `store.setOptionPropertyToBoolean(this.key, ["target_option_value"], "disabled", true);`
- Observe that the disabled checkbox item(s) are unclickable and visually distinct from the enabled ones