### PR TITLE
Defining Prop Override Behavior

### DIFF
--- a/src/components/FilterGrid.vue
+++ b/src/components/FilterGrid.vue
@@ -69,7 +69,6 @@ export default {
     synchronous: {
       type: Boolean,
       required: false,
-      default: false,
     },
     clearButton: {
       type: Boolean,

--- a/src/components/FilterGrid.vue
+++ b/src/components/FilterGrid.vue
@@ -112,7 +112,6 @@ export default {
 
       filterOverrides.forEach((key) => {
         if (filter.props && Object.keys(filter.props).includes(key)) {
-          console.log(key, filter.key, filter.props[key]);
           props[key] = filter.props[key];
         }
       });

--- a/src/components/FilterGrid.vue
+++ b/src/components/FilterGrid.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="rows(filters)">
     <div
       :class="'row harness-vue-bootstrap-filtergrid-row ' + rowClass"
       v-for="(row, idx) in rows(filters)"
@@ -18,7 +18,7 @@
       >
         <component
           :is="filter.component"
-          v-bind="{ filter, ...filter.props, ...$props, ...$attrs }"
+          v-bind="generateFilterProps(filter)"
           :key="pageDefinition.key + '-filtergrid-' + filter.key"
           :class="componentClass"
         />
@@ -94,6 +94,36 @@ export default {
       if (!this.synchronous && this.pageDefinition.loadData) {
         this.loadData();
       }
+    },
+    generateFilterProps(filter) {
+      // sometimes we need to know which to defer to, the grid props or the filter props
+      // so far the only behavior that this has had issues with is "synchronous"
+      // this is written so that we always defer to the grid, except where specified otherwise
+      // but you can use either override
+      const filterOverrides = ["synchronous"];
+      const gridOverrides = [];
+
+      let props = {
+        filter,
+        ...filter.props,
+        ...this.$props,
+        ...this.$attrs,
+      };
+
+      filterOverrides.forEach((key) => {
+        if (filter.props && Object.keys(filter.props).includes(key)) {
+          console.log(key, filter.key, filter.props[key]);
+          props[key] = filter.props[key];
+        }
+      });
+
+      gridOverrides.forEach((key) => {
+        const combo = { ...this.$props, ...this.$attrs };
+        if (Object.keys(combo).includes(key)) {
+          props[key] = combo[key];
+        }
+      });
+      return props;
     },
   },
 };


### PR DESCRIPTION
This PR includes a new developer functionality in the `FilterGrid` component that allows us to have granularity in prop overrides. 

For context, an expected behavior of `FilterGrid` is that it passes all of its `props` and `attrs` down to the child components (filters) that it renders, as well as the `props` of the filter itself. However, this has caused some unexpected behavior when a filter's props are overridden by the "default" of a `FilterGrid` prop.

For example, in a project, we would like to set `synchronous:true` on a set of filters so that when interacted with they run `setFilter` but not `loadData`, and `loadData` is run by another function. We don't however want to set that on the `FilterGrid`, just the individual filters - both so that the grid doesn't render an `apply filters` button, and so that we can choose which filters are synchronous and which aren't.

Because `synchronous` is a prop on `FilterGrid`, even if no value is passed to the grid, it sees the prop as `false` because there is no value. This cascades down to the child, overriding the filter's internal prop setting.

*** 
The fix implemented here is adding behavior in which we have a list of props that we should defer to the filter and a list that defers to the grid. If future props run into similar questions about deference, we can simply add to these lists and see them implemented.