### PR TITLE
Bootstrap 5 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+docs/.vitepress/cache/*

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,7 +1,7 @@
 
 import DefaultTheme from 'vitepress/theme'
 import { createPinia } from "pinia";
-import { harnessPlugin, harnessMixin, harnessStore } from "@rtidatascience/harness-vue"
+import { harnessPlugin, harnessMixin, useHarnessStore } from "@rtidatascience/harness-vue"
 import { harnessVueBootstrap } from "../../../src/harness-vue-bootstrap"
 import barchart from './barchart.vue'
 import pages from "../harness-pages/manifest"
@@ -22,7 +22,7 @@ export default {
     ctx.app.use(harnessVueBootstrap);
     ctx.app.component('barchart', barchart)
 
-    const harness = harnessStore(pinia)
+    const harness = useHarnessStore(pinia)
     const page = harness.getPageStores['examplePage'](pinia)    
     page.loadData()
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,8 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@popperjs/core": "^2.11.6",
-        "bootstrap": "^4.3.1",
+        "bootstrap": "^5.3.1",
         "bootstrap-icons": "^1.9.1",
-        "jquery": "^3.6.1",
         "vue": "^3.2.38"
       },
       "devDependencies": {
@@ -800,6 +798,7 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -1464,9 +1463,9 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.1.tgz",
+      "integrity": "sha512-jzwza3Yagduci2x0rr9MeFSORjcHpt0lRZukZPZQJT1Dth5qzV7XcgGqYzi39KGAVYR8QEDVoO0ubFKOxzMG+g==",
       "funding": [
         {
           "type": "github",
@@ -1478,8 +1477,7 @@
         }
       ],
       "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/bootstrap-icons": {
@@ -2705,11 +2703,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
-    "node_modules/jquery": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.0.tgz",
-      "integrity": "sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ=="
-    },
     "node_modules/js-beautify": {
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.9.tgz",
@@ -3305,17 +3298,6 @@
         "jsonc-parser": "^3.2.0",
         "mlly": "^1.2.0",
         "pathe": "^1.1.0"
-      }
-    },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/postcss": {
@@ -4935,7 +4917,8 @@
     "@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true
     },
     "@rtidatascience/harness-vue": {
       "version": "1.3.0",
@@ -5398,9 +5381,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.1.tgz",
+      "integrity": "sha512-jzwza3Yagduci2x0rr9MeFSORjcHpt0lRZukZPZQJT1Dth5qzV7XcgGqYzi39KGAVYR8QEDVoO0ubFKOxzMG+g==",
       "requires": {}
     },
     "bootstrap-icons": {
@@ -6284,11 +6267,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
-    "jquery": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.0.tgz",
-      "integrity": "sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ=="
-    },
     "js-beautify": {
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.9.tgz",
@@ -6706,12 +6684,6 @@
         "mlly": "^1.2.0",
         "pathe": "^1.1.0"
       }
-    },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "peer": true
     },
     "postcss": {
       "version": "8.4.27",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,8 @@
     "docs:serve": "vitepress serve docs"
   },
   "dependencies": {
-    "@popperjs/core": "^2.11.6",
-    "bootstrap": "^4.3.1",
+    "bootstrap": "^5.3.1",
     "bootstrap-icons": "^1.9.1",
-    "jquery": "^3.6.1",
     "vue": "^3.2.38"
   },
   "devDependencies": {

--- a/src/components/ChartWithTable.vue
+++ b/src/components/ChartWithTable.vue
@@ -15,7 +15,7 @@
                 <button
                   v-if="collapsible"
                   id="collapseButton"
-                  data-toggle="collapse"
+                  data-bs-toggle="collapse"
                   aria-expanded="false"
                   :aria-controls="
                     chart.key + 'ChartTableBody' + ' ' + chart.key + 'Buttons'

--- a/src/components/FilterAccordion.vue
+++ b/src/components/FilterAccordion.vue
@@ -11,7 +11,7 @@
           class="card-header"
           :id="filterType + '-heading'"
           @click="toggle"
-          data-toggle="collapse"
+          data-bs-toggle="collapse"
           :data-target="'#collapse-' + filterType"
         >
           <h2 class="mb-0">

--- a/src/components/inputs/HarnessVueBootstrapCheckboxGroup.vue
+++ b/src/components/inputs/HarnessVueBootstrapCheckboxGroup.vue
@@ -4,7 +4,7 @@
       <legend
         class="col-form-label harness-vue-bootstrap-checkboxgroup-legend"
         :for="filter.key"
-        :data-toggle="collapse ? 'collapse' : ''"
+        :data-bs-toggle="collapse ? 'collapse' : ''"
         :href="
           collapse
             ? '#harness-vue-bootstrap-checkbox-collapse-' + filter.key
@@ -15,7 +15,7 @@
         <span v-html="filter.label" />
         <button
           class="harness-vue-bootstrap-collapse-toggle-button"
-          :data-toggle="collapse ? 'collapse' : ''"
+          :data-bs-toggle="collapse ? 'collapse' : ''"
           :href="
             collapse
               ? '#harness-vue-bootstrap-checkbox-collapse-' + filter.key
@@ -32,7 +32,7 @@
       </legend>
       <div
         v-if="collapse"
-        data-toggle="collapse"
+        data-bs-toggle="collapse"
         :href="
           collapse
             ? '#harness-vue-bootstrap-checkbox-collapse-' + filter.key
@@ -93,7 +93,7 @@
         <div :class="'col-' + labelColumnSize">
           <legend
             class="col-form-label harness-vue-bootstrap-checkboxgroup-legend"
-            :data-toggle="collapse ? 'collapse' : ''"
+            :data-bs-toggle="collapse ? 'collapse' : ''"
             :href="
               collapse
                 ? '#harness-vue-bootstrap-checkbox-collapse-' + filter.key
@@ -105,7 +105,7 @@
             <span v-html="filter.label" />
             <button
               class="harness-vue-bootstrap-collapse-toggle-button"
-              :data-toggle="collapse ? 'collapse' : ''"
+              :data-bs-toggle="collapse ? 'collapse' : ''"
               :href="
                 collapse
                   ? '#harness-vue-bootstrap-checkbox-collapse-' + filter.key
@@ -125,7 +125,7 @@
           <div
             v-if="collapse"
             class="col-form-label harness-vue-bootstrap-checkboxgroup-collapse-label"
-            data-toggle="collapse"
+            data-bs-toggle="collapse"
             :href="'#harness-vue-bootstrap-checkbox-collapse-' + filter.key"
             role="button"
           >
@@ -208,6 +208,8 @@
 import inputProps from "../mixins/inputProps";
 import inputFilter from "../mixins/inputFilter";
 import CheckboxPartial from "./partials/CheckboxPartial.vue";
+import { Collapse } from "bootstrap";
+
 export default {
   name: "harness-vue-bootstrap-checkboxgroup",
   mixins: [inputProps, inputFilter],
@@ -234,20 +236,26 @@ export default {
       // when clicking anywhere but the checkboxes themselves
       document.addEventListener("click", (e) => {
         if (!e.target.id.includes(this.filter.key)) {
-          window
-            .$(`#harness-vue-bootstrap-checkbox-collapse-${this.filter.key}`)
-            .collapse("hide");
+          const el = document.querySelector(
+            `#harness-vue-bootstrap-checkbox-collapse-${this.filter.key}`,
+          );
+          const bsEl = Collapse.getInstance(el);
+          bsEl.hide();
         }
       });
       // lifecycling the vue attribute used for the chevron along with bootstrap
-      window
-        .$(`#harness-vue-bootstrap-checkbox-collapse-${this.filter.key}`)
-        .on("hide.bs.collapse", () => {
+      document
+        .querySelector(
+          `#harness-vue-bootstrap-checkbox-collapse-${this.filter.key}`,
+        )
+        .addEventListener("hide.bs.collapse", () => {
           this.collapsed = true;
         });
-      window
-        .$(`#harness-vue-bootstrap-checkbox-collapse-${this.filter.key}`)
-        .on("show.bs.collapse", () => {
+      document
+        .querySelector(
+          `#harness-vue-bootstrap-checkbox-collapse-${this.filter.key}`,
+        )
+        .addEventListener("show.bs.collapse", () => {
           this.collapsed = false;
         });
     }


### PR DESCRIPTION
Upgrading from Bootstrap 4 to Bootstrap 5. Given the extent of rewrites needed here, I'd also like to take the opportunity to move components to the composition API wherever possible.

- [ ] Upgrade Bootstrap from 4 to 5 and resolve dependencies
- [ ] Replace all `data-toggle` with `data-bs-toggle`
- [ ] Remove any jquery dependencies and use new Javascript API
- [ ] Investigate [form layout changes](https://getbootstrap.com/docs/5.0/migration/#forms) and update this list as needed 
- [ ] Fix helper text across inputs
- [ ] Fix append/prepend behavior across inputs
- [ ] Rewrite mixins as composables
- [ ] Rewrite components using composition API
- [ ] Update documentation