### PR TITLE
Fixing typos where pageDefinition was not coming from the harness object

### DIFF
--- a/src/components/grids/ChartGrid.vue
+++ b/src/components/grids/ChartGrid.vue
@@ -29,7 +29,7 @@ const chartRows = computed(() => rows(props, harness.charts));
             chart: { key: chart.key, ...chart },
             ...chart.props,
           }"
-          :key="pageDefinition.key + '-chartgrid-' + chart.key"
+          :key="harness.pageDefinition.key + '-chartgrid-' + chart.key"
           :class="componentClass"
         />
       </div>

--- a/src/components/grids/FilterGrid.vue
+++ b/src/components/grids/FilterGrid.vue
@@ -70,7 +70,7 @@ function initializeDefaultsLoadData() {
             filter: { key: filter.key, ...filter },
             ...filter.props,
           }"
-          :key="pageDefinition.key + '-filtergrid-' + filter.key"
+          :key="harness.pageDefinition.key + '-filtergrid-' + filter.key"
           :class="componentClass"
         />
       </div>


### PR DESCRIPTION
This fixes a bug in the grids where they referenced `pageDefinition` instead of `harness.pageDefinition`. This largely went unnoticed because our starter templates installed the options API mixin which maps the entirety of the pinia store to every component. We noticed that removing the mixin (intended only for options API compatibility) in our composition-only apps broke due to this missing reference.