### PR TITLE
adding helperTextPosition prop

### DIFF
--- a/docs/components/filters/checkboxGroup.md
+++ b/docs/components/filters/checkboxGroup.md
@@ -134,6 +134,18 @@ This property allows a developer to specify a class to be appended to their `hel
 <harness-vue-bootstrap-checkbox-group :helperText="'Helper text with contextual information, styled as text-success'" :helperTextClass="'text-success'"/>
 ```
 
+### helperTextPosition
+This property allows a developer to specify that the helper text is rendered below the label or below the input.
+* **Type**: `String`
+* **Required**: No
+* **Default**: `'input'`
+
+```html
+<harness-vue-bootstrap-checkbox-group :helperText="'Helper text with contextual information below label'" :helperTextPosition="'label'"/>
+```
+#### Example
+<harness-vue-bootstrap-checkbox-group :filter="{'key': 'exampleCheckboxGroup5', 'label': 'Example Checkbox Group'}"  :helperText="'Helper text with contextual information below label'" :helperTextPosition="'label'"/>
+
 ### inline
 If harness-vue-bootstrap-checkbox-group is given the `inline` prop, the checkbox options will be placed inline instead of stacked. 
 * **Type**: `Booolean`

--- a/docs/components/filters/input.md
+++ b/docs/components/filters/input.md
@@ -116,6 +116,18 @@ This property allows a developer to specify a class to be appended to their `hel
     :helperTextClass="'text-success'"
     />
 ```
+### helperTextPosition
+This property allows a developer to specify that the helper text is rendered below the label or below the input.
+* **Type**: `String`
+* **Required**: No
+* **Default**: `'input'`
+
+```html
+<harness-vue-bootstrap-input :helperText="'Helper text with contextual information below label'" :helperTextPosition="'label'"/>
+```
+#### Example
+<harness-vue-bootstrap-input :filter="{'key': 'exampleInput', 'label': 'Example Input'}"  :helperText="'Helper text with contextual information below label'" :helperTextPosition="'label'"/>
+
 ***
 ### inputClearButton
 Adds a clear button to the end of the input group.

--- a/docs/components/filters/select.md
+++ b/docs/components/filters/select.md
@@ -150,6 +150,20 @@ This property allows a developer to specify a class to be appended to their `hel
 <harness-vue-bootstrap-select :helperText="'Helper text with contextual information, styled as text-success'" :helperTextClass="'text-success'"/>
 ```
 
+### helperTextPosition
+This property allows a developer to specify that the helper text is rendered below the label or below the input.
+* **Type**: `String`
+* **Required**: No
+* **Default**: `'input'`
+
+```html
+<harness-vue-bootstrap-select :helperText="'Helper text with contextual information below label'" :helperTextPosition="'label'"/>
+```
+#### Example
+<harness-vue-bootstrap-select :filter="{'key': 'exampleSelect', 'label': 'Example Input'}"  :helperText="'Helper text with contextual information below label'" :helperTextPosition="'label'"/>
+
+***
+
 ### multiple
 If harness-vue-bootstrap-select is given the `multiple` prop, it will be treated as a multi-select filter. Please note that it is required that this prop is set in your harness page definition - this is what informs harness to treat the contents of this filter as an `Array` instead of a `String`. 
 * **Type**: `Booolean`

--- a/src/components/inputs/HarnessVueBootstrapCheckboxGroup.vue
+++ b/src/components/inputs/HarnessVueBootstrapCheckboxGroup.vue
@@ -146,10 +146,10 @@ const getWrapperClassString = computed(() => {
         ></div>
       </div>
       <small
-        v-if="props.helperText"
+        v-if="props.helperText && props.helperTextPosition == 'input'"
         v-html="props.helperText"
         :id="`${props.filter.key}-helper-text`"
-        :class="`form-text harness-vue-bootstrap-helper-text harness-vue-bootstrap-checkbox-helper-text ${props.helperTextClass}`"
+        :class="`form-text harness-vue-bootstrap-helper-text harness-vue-bootstrap-helper-text-input harness-vue-bootstrap-checkbox-helper-text ${props.helperTextClass}`"
       />
       <!-- Validity Messages -->
     </template>

--- a/src/components/inputs/HarnessVueBootstrapInput.vue
+++ b/src/components/inputs/HarnessVueBootstrapInput.vue
@@ -209,9 +209,9 @@ const getInputClassString = computed(() => {
         :required="props.required"
       />
       <small
-        v-if="props.helperText"
+        v-if="props.helperText && props.helperTextPosition == 'input'"
         v-html="props.helperText"
-        :class="`form-text harness-vue-bootstrap-helper-text harness-vue-bootstrap-input-helper-text ${props.helperTextClass}`"
+        :class="`form-text harness-vue-bootstrap-helper-text harness-vue-bootstrap-helper-text-input harness-vue-bootstrap-input-helper-text ${props.helperTextClass}`"
         :id="`${props.filter.key}-helper-text`"
       />
       <!-- Validity Messages -->

--- a/src/components/inputs/HarnessVueBootstrapSelect.vue
+++ b/src/components/inputs/HarnessVueBootstrapSelect.vue
@@ -171,10 +171,10 @@ const getInputClassString = computed(() => {
         />
       </select>
       <small
-        v-if="props.helperText"
+        v-if="props.helperText && props.helperTextPosition == 'input'"
         v-html="props.helperText"
         :id="`${props.filter.key}-helper-text`"
-        :class="`form-text harness-vue-bootstrap-helper-text harness-vue-bootstrap-input-helper-text ${props.helperTextClass}`"
+        :class="`form-text harness-vue-bootstrap-helper-text harness-vue-bootstrap-helper-text-input harness-vue-bootstrap-input-helper-text ${props.helperTextClass}`"
       />
       <!-- Validity Messages -->
       <div

--- a/src/components/inputs/labelPartial.vue
+++ b/src/components/inputs/labelPartial.vue
@@ -27,4 +27,10 @@ const labelClassString = computed(() => {
     :class="labelClassString"
     v-html="props.filter.label"
   />
+  <p
+    v-if="props.helperTextPosition == 'label' && props.helperText"
+    :id="`${props.filter.key}-helper-text`"
+    :class="`form-text harness-vue-bootstrap-helper-text harness-vue-bootstrap-helper-text-label ${props.helperTextClass}`"
+    v-html="props.helperText"
+  />
 </template>

--- a/src/components/inputs/utils/sharedInputProps.js
+++ b/src/components/inputs/utils/sharedInputProps.js
@@ -35,6 +35,11 @@ export const sharedFilterProps = {
     required: false,
     default: "",
   },
+  helperTextPosition: {
+    type: String,
+    required: false,
+    default: "input",
+  },
   prependComponent: {
     required: false,
     type: Object,


### PR DESCRIPTION
As requested!

This PR adds a new prop for inputs called `helperTextPosition` that defaults to `input` but can be set to `label`. If set to `label`, the helper text is rendered below the label instead of below the input. This retains the existing `aria-describedby` behavior.