### PR TITLE
Label id fixes

### DIFF
--- a/docs/components/filters/input.md
+++ b/docs/components/filters/input.md
@@ -42,6 +42,13 @@ options: [
 ```
 
 ## Props
+
+### additionalDescribedByIds
+An array of IDs included in the [aria-describedby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attribute of the form control. Used when developers have additional elements that describe the given input.
+* **Type**: `Array`
+* **Required**: No
+* **Default**: []
+
 ### appendHTML
 Specify text to be appended to the input using a bootstrap input group.
 * **Type**: `String`

--- a/docs/components/filters/select.md
+++ b/docs/components/filters/select.md
@@ -30,6 +30,12 @@ components.harnessVueBootstrapSelect // object syntax
 ```
 ## Props
 
+### additionalDescribedByIds
+An array of IDs included in the [aria-describedby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attribute of the form control. Used when developers have additional elements that describe the given input.
+* **Type**: `Array`
+* **Required**: No
+* **Default**: []
+
 ### appendHTML
 Specify text to be appended to the input using a bootstrap input group.
 * **Type**: `String`

--- a/src/components/inputs/HarnessVueBootstrapSelect.vue
+++ b/src/components/inputs/HarnessVueBootstrapSelect.vue
@@ -90,7 +90,7 @@ const getInputClassString = computed(() => {
           :class="getInputClassString"
           :disabled="props.disabled"
           v-model="boundValue"
-          :id="`${props.filter.key}-select`"
+          :id="`${props.filter.key}`"
           :aria-labelledby="`${props.filter.key}-label`"
           :aria-label="props.filter.label"
           :aria-describedby="describedBy"
@@ -101,6 +101,7 @@ const getInputClassString = computed(() => {
           <option
             v-for="option in harness.getOptionsForFilter(props.filter.key)"
             :key="option.key"
+            :id="`${props.filter.key}-${option.key}`"
             :value="option.key"
             :disabled="option.disabled"
             :hidden="option.hidden"
@@ -152,7 +153,7 @@ const getInputClassString = computed(() => {
         :class="getInputClassString"
         :disabled="props.disabled"
         v-model="boundValue"
-        :id="`${props.filter.key}-select`"
+        :id="`${props.filter.key}`"
         :aria-labelledby="`${props.filter.key}-label`"
         :aria-label="props.filter.label"
         :aria-describedby="describedBy"
@@ -163,6 +164,7 @@ const getInputClassString = computed(() => {
         <option
           v-for="option in harness.getOptionsForFilter(props.filter.key)"
           :key="option.key"
+          :id="`${props.filter.key}-${option.key}`"
           :value="option.key"
           :disabled="option.disabled"
           :hidden="option.hidden"

--- a/src/components/inputs/labelPartial.vue
+++ b/src/components/inputs/labelPartial.vue
@@ -26,6 +26,7 @@ const labelClassString = computed(() => {
     :for="props.filter.key"
     :class="labelClassString"
     v-html="props.filter.label"
+    :id="`${props.filter.key}-label`"
   />
   <p
     v-if="props.helperTextPosition == 'label' && props.helperText"

--- a/src/components/inputs/utils/sharedInputProps.js
+++ b/src/components/inputs/utils/sharedInputProps.js
@@ -86,6 +86,11 @@ export const sharedFilterProps = {
     type: Boolean,
     default: true,
   },
+  additionalDescribedByIds: {
+    required: false,
+    type: Array,
+    default: [],
+  },
 };
 
 export const isFilterProp = {

--- a/src/components/inputs/utils/useDescribedBy.js
+++ b/src/components/inputs/utils/useDescribedBy.js
@@ -34,6 +34,10 @@ export default function useDescribedBy(props) {
       describedByClassList.push(`${props.filter.key}-helper-text`);
     }
 
+    if (props.additionalDescribedByIds) {
+      describedByClassList.push(...props.additionalDescribedByIds);
+    }
+
     return describedByClassList.join(" ");
   });
 }


### PR DESCRIPTION
This PR includes the following accessibility-focused changes:

- Fixed an issue in which labels were missing IDs
- Fixed an issue in which the IDs of `<select>` elements were not matching the `<label for="">` target
- Added the ability for developers to provide additional `aria-describedby` ids to `input` and `select` form controls