### PR TITLE
moving the label helper text out of the label component

### DIFF
--- a/src/components/inputs/formControlWrapper.vue
+++ b/src/components/inputs/formControlWrapper.vue
@@ -63,6 +63,12 @@ const getWrapperClass = computed(() => {
           props.labelPosition.toLowerCase() !== 'floating'
         "
       />
+      <p
+        v-if="props.helperTextPosition == 'label' && props.helperText"
+        :id="`${props.filter.key}-helper-text`"
+        :class="`form-text harness-vue-bootstrap-helper-text harness-vue-bootstrap-helper-text-label ${props.helperTextClass}`"
+        v-html="props.helperText"
+      />
     </div>
     <div :class="getInputWrapperClass">
       <slot name="input"></slot>

--- a/src/components/inputs/labelPartial.vue
+++ b/src/components/inputs/labelPartial.vue
@@ -22,18 +22,10 @@ const labelClassString = computed(() => {
 });
 </script>
 <template>
-  <div>
-    <label
-      :for="props.filter.key"
-      :class="labelClassString"
-      v-html="props.filter.label"
-      :id="`${props.filter.key}-label`"
-    />
-    <p
-      v-if="props.helperTextPosition == 'label' && props.helperText"
-      :id="`${props.filter.key}-helper-text`"
-      :class="`form-text harness-vue-bootstrap-helper-text harness-vue-bootstrap-helper-text-label ${props.helperTextClass}`"
-      v-html="props.helperText"
-    />
-  </div>
+  <label
+    :for="props.filter.key"
+    :class="labelClassString"
+    v-html="props.filter.label"
+    :id="`${props.filter.key}-label`"
+  />
 </template>


### PR DESCRIPTION
In the recent new feature to allow developers to put helper text under labels, we wrapped the label and helper text in a single parent node to not violate SFC conventions. This is not compatible with bootstrap's CSS for floating labels. The solution is to move this into the form control wrapper.