### PR TITLE
use harness getFilters for table adapter

### DIFF
--- a/src/components/tables/BasicTable.vue
+++ b/src/components/tables/BasicTable.vue
@@ -49,7 +49,7 @@ const chartData = computed(() => {
       try {
         return tableAdapter(
           props.chart,
-          props.filters,
+          harness.getFilters,
           chartData,
           harness.pageStore,
         );


### PR DESCRIPTION
PR fixes an issue where the table adapter was returning undefined for filters.