### PR TITLE
Conditional title prop for ChartWithTable

### DIFF
--- a/docs/components/charts-and-tables/chartWithTable.md
+++ b/docs/components/charts-and-tables/chartWithTable.md
@@ -52,7 +52,7 @@ Adds a download button that downloads a CSV representation of the chart data.
 * **Default**: `true`
 
 #### Example downloadable false
-<chart-with-table :chart="{key: 'exampleChartWithTable', title: 'Example Chart'}" :chartComponent="'barchart'" :refName="'downloadable-false-example'" :showDownloadButton="false" :titleDisplayContext="'chart'"/>
+<chart-with-table :chart="{key: 'exampleChartWithTable', title: 'Example Chart'}" :chartComponent="'barchart'" :refName="'downloadable-false-example'" :showDownloadButton="false"/>
 
 ```html
 <ChartWithTable :chart="{ key: 'exampleChartWithTable' }" :chartComponent="barChart" :downloadable="false"/>
@@ -68,7 +68,7 @@ Directs butttons to be in the card header or footer.
 * **Default**: `'header'`
 
 #### Example button bottom
-<chart-with-table :chart="{key: 'exampleChartWithTable', title: 'Example Chart'}" :chartComponent="'barchart'" :refName="'button-bottom-example'" :buttonPosition="'footer'" :titleDisplayContext="'table'"/>
+<chart-with-table :chart="{key: 'exampleChartWithTable', title: 'Example Chart'}" :chartComponent="'barchart'" :refName="'button-bottom-example'" :buttonPosition="'footer'"/>
 
 ```html
 <ChartWithTable :chart="{ key: 'exampleChartWithTable' }" :chartComponent="barChart" :buttonPosition="'bottom'"/>

--- a/docs/components/charts-and-tables/chartWithTable.md
+++ b/docs/components/charts-and-tables/chartWithTable.md
@@ -101,11 +101,14 @@ Allows a user-specified label for the download button.
 <ChartWithTable :chart="{ key: 'exampleChartWithTable' }" :chartComponent="barChart" :showChartButtonText="'Show Me The Chart'" :showTableButtonText="'Show Me The Table'" :downloadButtonText="'Give Me The CSV'"/>
 ```
 
-### showTitleForViews
-Allows user to specify when title is displayed.
-* **Type**: `Array`
+### titleOnlyFor
+Specifies when the title is displayed, based on the current view. Omitting this prop will display the title in both views.
+* **Type**: `String`
 * **Required**: No
-* **Default**: `["chart", "table"]`
+* **Options:**
+    * `'chart'`
+    * `'table'`
+* **Default**: null
 
 ***
 ## Slots

--- a/docs/components/charts-and-tables/chartWithTable.md
+++ b/docs/components/charts-and-tables/chartWithTable.md
@@ -58,6 +58,7 @@ Adds a download button that downloads a CSV representation of the chart data.
 <ChartWithTable :chart="{ key: 'exampleChartWithTable' }" :chartComponent="barChart" :downloadable="false"/>
 ```
 ***
+
 ### buttonPosition
 Directs butttons to be in the card header or footer.
 * **Type**: `String`

--- a/docs/components/charts-and-tables/chartWithTable.md
+++ b/docs/components/charts-and-tables/chartWithTable.md
@@ -52,13 +52,12 @@ Adds a download button that downloads a CSV representation of the chart data.
 * **Default**: `true`
 
 #### Example downloadable false
-<chart-with-table :chart="{key: 'exampleChartWithTable', title: 'Example Chart'}" :chartComponent="'barchart'" :refName="'downloadable-false-example'" :showDownloadButton="false"/>
+<chart-with-table :chart="{key: 'exampleChartWithTable', title: 'Example Chart'}" :chartComponent="'barchart'" :refName="'downloadable-false-example'" :showDownloadButton="false" :titleDisplayContext="'chart'"/>
 
 ```html
 <ChartWithTable :chart="{ key: 'exampleChartWithTable' }" :chartComponent="barChart" :downloadable="false"/>
 ```
 ***
-
 ### buttonPosition
 Directs butttons to be in the card header or footer.
 * **Type**: `String`
@@ -69,7 +68,7 @@ Directs butttons to be in the card header or footer.
 * **Default**: `'header'`
 
 #### Example button bottom
-<chart-with-table :chart="{key: 'exampleChartWithTable', title: 'Example Chart'}" :chartComponent="'barchart'" :refName="'button-bottom-example'" :buttonPosition="'footer'"/>
+<chart-with-table :chart="{key: 'exampleChartWithTable', title: 'Example Chart'}" :chartComponent="'barchart'" :refName="'button-bottom-example'" :buttonPosition="'footer'" :titleDisplayContext="'table'"/>
 
 ```html
 <ChartWithTable :chart="{ key: 'exampleChartWithTable' }" :chartComponent="barChart" :buttonPosition="'bottom'"/>
@@ -109,6 +108,13 @@ Specifies when the title is displayed based on the view. Omitting this prop will
     * `'chart'`
     * `'table'`
 * **Default**: null
+
+#### Example with conditional title
+<chart-with-table :chart="{key: 'exampleChartWithTable', title: 'Example Chart'}" :chartComponent="'barchart'" :titleDisplayContext="'table'"/>
+
+```html
+<chart-with-table :chart="{key: 'exampleChartWithTable', title: 'Example Chart'}" :chartComponent="'barchart'" :titleDisplayContext="'table'"/>
+```
 
 ***
 ## Slots

--- a/docs/components/charts-and-tables/chartWithTable.md
+++ b/docs/components/charts-and-tables/chartWithTable.md
@@ -100,6 +100,13 @@ Allows a user-specified label for the download button.
 ```html
 <ChartWithTable :chart="{ key: 'exampleChartWithTable' }" :chartComponent="barChart" :showChartButtonText="'Show Me The Chart'" :showTableButtonText="'Show Me The Table'" :downloadButtonText="'Give Me The CSV'"/>
 ```
+
+### showTitleForViews
+Allows user to specify when title is displayed.
+* **Type**: `Array`
+* **Required**: No
+* **Default**: `["chart", "table"]`
+
 ***
 ## Slots
 

--- a/docs/components/charts-and-tables/chartWithTable.md
+++ b/docs/components/charts-and-tables/chartWithTable.md
@@ -101,8 +101,8 @@ Allows a user-specified label for the download button.
 <ChartWithTable :chart="{ key: 'exampleChartWithTable' }" :chartComponent="barChart" :showChartButtonText="'Show Me The Chart'" :showTableButtonText="'Show Me The Table'" :downloadButtonText="'Give Me The CSV'"/>
 ```
 
-### titleOnlyFor
-Specifies when the title is displayed, based on the current view. Omitting this prop will display the title in both views.
+### titleDisplayContext
+Specifies when the title is displayed based on the view. Omitting this prop will display the title in both views.
 * **Type**: `String`
 * **Required**: No
 * **Options:**

--- a/src/components/tables/ChartWithTable.vue
+++ b/src/components/tables/ChartWithTable.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { defineProps, ref } from "vue";
+import { defineProps, ref, computed } from "vue";
 import { useHarnessComposable } from "@rtidatascience/harness-vue";
 
 const harness = useHarnessComposable();
@@ -40,9 +40,21 @@ const props = defineProps({
     required: false,
     default: "Download as CSV",
   },
+  showTitleForViews: {
+    type: Array,
+    required: false,
+    default: () => ["chart", "table"],
+    validator: function (value) {
+      return value.every((v) => ["chart", "table"].includes(v));
+    },
+  },
 });
 
 const view = ref("chart");
+
+const showTitle = computed(
+  () => props.showTitleForViews.includes(view.value) && props.chart.title,
+);
 
 function toggleView() {
   switch (view.value) {
@@ -63,9 +75,10 @@ function toggleView() {
           ? 'justify-content-between'
           : 'justify-content-start'
       }`"
-      v-if="props.chart.title || props.buttonPosition === 'header'"
+      v-if="showTitle || props.buttonPosition === 'header'"
     >
-      {{ props.chart.title }}
+      <span v-if="showTitle">{{ props.chart.title }}</span>
+      <span v-else></span>
       <span
         class="harness-vue-bootstrap-chartwithtable-header-buttons"
         v-if="props.buttonPosition === 'header'"

--- a/src/components/tables/ChartWithTable.vue
+++ b/src/components/tables/ChartWithTable.vue
@@ -40,21 +40,22 @@ const props = defineProps({
     required: false,
     default: "Download as CSV",
   },
-  showTitleForViews: {
-    type: Array,
+  titleOnlyFor: {
+    type: String,
     required: false,
-    default: () => ["chart", "table"],
+    default: null,
     validator: function (value) {
-      return value.every((v) => ["chart", "table"].includes(v));
+      return ["chart", "table"].includes(value);
     },
   },
 });
 
 const view = ref("chart");
 
-const showTitle = computed(
-  () => props.showTitleForViews.includes(view.value) && props.chart.title,
-);
+const showTitle = computed(() => {
+  if (!props.titleOnlyFor) return !!props.chart.title;
+  return props.titleOnlyFor === view.value;
+});
 
 function toggleView() {
   switch (view.value) {

--- a/src/components/tables/ChartWithTable.vue
+++ b/src/components/tables/ChartWithTable.vue
@@ -40,7 +40,7 @@ const props = defineProps({
     required: false,
     default: "Download as CSV",
   },
-  titleOnlyFor: {
+  titleDisplayContext: {
     type: String,
     required: false,
     default: null,
@@ -53,8 +53,8 @@ const props = defineProps({
 const view = ref("chart");
 
 const showTitle = computed(() => {
-  if (!props.titleOnlyFor) return !!props.chart.title;
-  return props.titleOnlyFor === view.value;
+  if (!props.titleDisplayContext) return !!props.chart.title;
+  return props.titleDisplayContext === view.value;
 });
 
 function toggleView() {


### PR DESCRIPTION
This PR introduces a new prop, `titleDisplayContext`, to the `ChartWithTable` component. This prop allows users to specify when the title should be displayed, depending on the current view (either 'chart' or 'table').

The motivation behind this change is to accommodate scenarios where the chart component may need to display its title (especially useful when the chart is downloadable), while still providing the option to display a separate title when the table view is active.