### PR TITLE
Issue #13, Allow option descriptions to be used as HTML title attributes in Selects

### DIFF
--- a/docs/.vitepress/harness-pages/examplePage.js
+++ b/docs/.vitepress/harness-pages/examplePage.js
@@ -105,6 +105,31 @@ export default class ExamplePage {
           },
         ],
       },
+      exampleSelectLabel: {
+        key: "exampleSelectLabel",
+        label: "Example Select with Label",
+        component: "HarnessVueBootstrapSelect",
+        props: {
+          filterType: "internal",
+        },
+        options: [
+          {
+            key: "exampleOption",
+            label: "Example Option",
+            description: "This is a sample description replacing the title attribute",
+            default: true,
+          },
+          {
+            key: "exampleOption2",
+            label: "Example Option 2",
+          },
+          {
+            key: "exampleOption3",
+            label: "Example Option 3",
+            description: "This is a sample description for Example Option 3"
+          },
+        ],
+      },
       exampleMultiSelect: {
         key: "exampleMultiSelect",
         label: "Example Multiselect",

--- a/docs/components/filters/select.md
+++ b/docs/components/filters/select.md
@@ -210,4 +210,38 @@ Specify a component to be prepended to the select using a [bootstrap select grou
     :prependComponent="component"
     />
 ```
+
+## Additional Features
+### Overriding `title` attribute
+The `title` attribute of the select options can be overridden by providing a `description` attribute in the filter's options. When the `description` attribute is present, the select component will use its value as the `title` attribute for the options. This causes the tooltip that appears when hovering an option in the select menu to display the value of the `description` attribute. If no `description` attribute is provided, the default behavior sets the `title` attribute to the provided option label.
+#### Example Filter Definition
+```html
+exampleSelectLabel: {
+    key: "exampleSelectLabel",
+    label: "Example Select with Label",
+    component: "HarnessVueBootstrapSelect",
+    props: {
+        filterType: "internal",
+    },
+    options: [
+        {
+            key: "exampleOption",
+            label: "Example Option",
+            description: "This is a sample description replacing the title attribute",
+            default: true,
+        },
+        {
+            key: "exampleOption2",
+            label: "Example Option 2",
+        },
+        {
+            key: "exampleOption3",
+            label: "Example Option 3",
+            description: "This is a sample description for Example Option 3"
+        },
+    ],
+}
+```
+#### Example
+<harness-vue-bootstrap-select :filter="getFilterDefinition('exampleSelectLabel')"/>
 ***

--- a/src/components/inputs/HarnessVueBootstrapSelect.vue
+++ b/src/components/inputs/HarnessVueBootstrapSelect.vue
@@ -105,7 +105,7 @@ const getInputClassString = computed(() => {
             :value="option.key"
             :disabled="option.disabled"
             :hidden="option.hidden"
-            :title="option.label"
+            :title="`${option.description ? option.description : option.label}`"
             v-html="option.label"
           />
         </select>
@@ -168,7 +168,7 @@ const getInputClassString = computed(() => {
           :value="option.key"
           :disabled="option.disabled"
           :hidden="option.hidden"
-          :title="option.label"
+          :title="`${option.description ? option.description : option.label}`"
           v-html="option.label"
         />
       </select>


### PR DESCRIPTION
# Allow Overriding HTML title attributes for select options

## Description
This PR introduces logic to the HarnessVueBootstrapSelect component that allows the user to specify an optional description attribute in the filter options. If a description attribute is not provided, the component will default to setting the HTML title attribute as the provided option label. If one is provided, the component will use that value as the provided option label.

The motivation behind this change is to accommodate scenarios where the user would want to display an alternative tooltip when hovering over an option in the select component.